### PR TITLE
Add env variable to not force SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 docker run --rm -e PASSWORD=FSBhuNOR -p 21000:21 -p 20000:20000 rhrn/vsftpd:latest
 ```
 
+* test server with optional SSL via command line
+```
+docker run --rm -e PASSWORD=FSBhuNOR -e FORCE_SSL=NO -p 21000:21 -p 20000:20000 rhrn/vsftpd:latest
+```
+
 * push file
 ```
 touch test.txt

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,14 @@ cp /etc/vsftpd/vsftpd.conf /etc/vsftpd/vsftpd.custom.conf
 
 sed -i "s/anonymous_enable=YES/anonymous_enable=NO/" /etc/vsftpd/vsftpd.custom.conf
 
+FORCE_LOCAL_DATA_SSL=YES
+FORCE_LOCAL_LOGINS_SSL=YES
+
+if [[ "${FORCE_SSL}" == "NO" ]]; then
+  FORCE_LOCAL_DATA_SSL=NO
+  FORCE_LOCAL_LOGINS_SSL=NO
+fi
+
 cat <<EOF >> /etc/vsftpd/vsftpd.custom.conf
 ssl_enable=YES
 rsa_cert_file=/etc/vsftpd/vsftpd.pem
@@ -15,8 +23,8 @@ ssl_tlsv1=YES
 ssl_sslv2=NO
 ssl_sslv3=NO
 ssl_ciphers=HIGH
-force_local_data_ssl=YES
-force_local_logins_ssl=YES
+force_local_data_ssl=$FORCE_LOCAL_DATA_SSL
+force_local_logins_ssl=$FORCE_LOCAL_LOGINS_SSL
 allow_anon_ssl=NO
 require_ssl_reuse=NO
 seccomp_sandbox=NO


### PR DESCRIPTION
Handy when testing both secure and unsecure FTP service on a single server (such as a CircleCI instance).